### PR TITLE
Added docs about print functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "description": "Proton's Smart Contract docs.",
   "scripts": {
-    "start": "npm run dev",
+    "start": "yarn dev",
     "dev": "vuepress dev src",
     "build": "vuepress build src"
   },

--- a/src/.vuepress/sidebar.js
+++ b/src/.vuepress/sidebar.js
@@ -55,7 +55,7 @@ function getDefaultSidebar() {
         { title: 'Authentication', path: '/api/authentication' },
         { title: 'Blockchain Time', path: '/api/currentTime' },
         { title: 'Cryptography', path: '/api/cryptography' },
-        { title: 'Debug', path: '/api/debug' },
+        { title: 'Print', path: '/api/print' },
 
       ]
     },

--- a/src/.vuepress/sidebar.js
+++ b/src/.vuepress/sidebar.js
@@ -55,6 +55,8 @@ function getDefaultSidebar() {
         { title: 'Authentication', path: '/api/authentication' },
         { title: 'Blockchain Time', path: '/api/currentTime' },
         { title: 'Cryptography', path: '/api/cryptography' },
+        { title: 'Debug', path: '/api/debug' },
+
       ]
     },
     {

--- a/src/api/debug.md
+++ b/src/api/debug.md
@@ -1,0 +1,264 @@
+---
+description: Debug
+---
+
+# Debug
+
+## print
+
+* ```ts
+  function print(value: string): void
+  ```
+  ```ts
+  function prints(value: string): void
+  ```
+  ```ts
+  function printString(value: string): void
+  ```
+  All these functions are aliases. They print value as a string. 
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    print('Hello! I am print');
+    // Output: 
+    // DEBUG: prints_l Hello! I am print
+
+    prints('Hello! I am prints');
+    // Output
+    // DEBUG: prints_l Hello! I am prints
+
+    printString('Hello! I am printString');
+    // Output
+    // DEBUG: prints_l Hello! I am printString
+  }
+  ```
+
+## printui
+
+* ```ts
+  function printui(value: u64): void
+  ```
+  Prints value as a 64 bit unsigned integer.
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
+    printui(<u64>1e+18); 
+    // Output: 
+    // DEBUG: printui 1000000000000000000
+  }
+  ```
+
+## printi
+
+* ```ts
+  function printi(value: i64): void
+  ```
+  Prints value as a 64 bit signed integer. 
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
+    printi(<i64>-1e+18); 
+    // Output: 
+    // DEBUG: printi -1000000000000000000
+
+    // Be careful with types:
+    printi(<i64>10); // DEBUG: printi 10
+    printui(<i64>10); // DEBUG: printui 10
+
+    // But 
+    printi(<i64>-10); // DEBUG: printi -10
+    printui(<i64>-10); // DEBUG: printui 18446744073709551606
+  }
+  ```
+
+## printI128
+* ```ts
+  function printI128(value: I128): void
+  ```
+  Prints value as a 128 bit signed integer
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    // NEED example here with proper type casting
+  }
+  ```
+
+## printU128
+* ```ts
+  function printU128(value: U128): void
+  ```
+  Prints value as a 128 bit unsigned integer
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    // NEED example here with proper type casting
+  }
+  ```
+
+## printsf
+* ```ts
+  function printsf(value: f32): void
+  ```
+  Prints value as single-precision floating point number
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    printsf(123.4);
+    // Output 
+    // DEBUG: printsf 123.4000015258789
+    printsf(123.45);
+    // Output
+    // DEBUG: printsf 123.44999694824219
+    printsf(123.456);
+    // Output
+    // DEBUG: printsf 123.45600128173828
+  }
+  ```
+
+## printdf
+* ```ts
+  function printdf(value: f64): void
+  ```
+  Prints value as double-precision floating point number
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    printsdf(123.456789);
+    // Output
+    // DEBUG: printsdf 123.456789
+    printsdf(123.45678912345679);
+    // Output
+    // DEBUG: printsdf 123.45678912345679
+  }
+  ```
+
+## printqf
+* ```ts
+  function printqf(value: Float128): void
+  ```
+  Prints value as quadruple-precision floating point number
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    // NEED example here with proper type casting
+  }
+  ```
+
+## printn
+* ```ts
+  function printn(value: Name): void
+  ```
+  Prints a 64 bit names as base32 encoded string
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    printn(Name.fromString('contract'))
+    // Output
+    // DEBUG: printn contract
+  }
+  ```
+
+## printArray
+* ```ts
+  function printArray(data: u8[]): void
+  ```
+  ?? Not clear how the function should be used. No examples provided.
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    printArray([
+        0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64
+    ])
+    // Output:
+    // DEBUG: prints Hello world
+
+    // ! Need to provide examples here
+  }
+  ```
+
+## printHex
+* ```ts
+  function printHex(data: u8[]): void
+  ```
+  Prints hexidecimal data
+
+  The function should be used inside the action method of the contract. 
+  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+
+  NOT FULLY CLEAN WHAT THIS FUNCTION IS FOR. AND WHAT ARE EXAMPLES.
+
+  <sub>**Example:**</sub>
+  ```ts
+  // ...
+  @action('act')
+  doAction(): void {
+    printHex([
+        0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64
+    ])
+    // Output
+    // DEBUG: printhex 48656c6c6f20776f726c64
+    // ! Need to provide examples here
+  }
+  ```

--- a/src/api/print.md
+++ b/src/api/print.md
@@ -2,39 +2,36 @@
 description: Debug
 ---
 
-# Debug
+# Print
+
+Print functions are the Proton equivalent of `console.log` and will be visible in console when you run tests with LOG_LEVEL=debug
 
 ## print
 
 * ```ts
   function print(value: string): void
   ```
-  ```ts
+* ```ts
   function prints(value: string): void
   ```
-  ```ts
+* ```ts
   function printString(value: string): void
   ```
-  All these functions are aliases. They print value as a string. 
-
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+  All these functions are aliases. 
+  
+  Prints value as a string. 
 
   <sub>**Example:**</sub>
   ```ts
-  // ...
   @action('act')
   doAction(): void {
     print('Hello! I am print');
+    prints('Hello! I am prints');
+    printString('Hello! I am printString');
+
     // Output: 
     // DEBUG: prints_l Hello! I am print
-
-    prints('Hello! I am prints');
-    // Output
     // DEBUG: prints_l Hello! I am prints
-
-    printString('Hello! I am printString');
-    // Output
     // DEBUG: prints_l Hello! I am printString
   }
   ```
@@ -46,18 +43,17 @@ description: Debug
   ```
   Prints value as a 64 bit unsigned integer.
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
-  // ...
   @action('act')
   doAction(): void {
     // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
     printui(<u64>1e+18); 
+    printui(<i64>-10);
+
     // Output: 
     // DEBUG: printui 1000000000000000000
+    // DEBUG: printui 18446744073709551606
   }
   ```
 
@@ -68,26 +64,19 @@ description: Debug
   ```
   Prints value as a 64 bit signed integer. 
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
-  // ...
   @action('act')
   doAction(): void {
     // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
-    printi(<i64>-1e+18); 
+    printi(<i64>-1e+18);
+    printi(<i64>10);
+    printi(<i64>-10);
+
     // Output: 
     // DEBUG: printi -1000000000000000000
-
-    // Be careful with types:
-    printi(<i64>10); // DEBUG: printi 10
-    printui(<i64>10); // DEBUG: printui 10
-
-    // But 
-    printi(<i64>-10); // DEBUG: printi -10
-    printui(<i64>-10); // DEBUG: printui 18446744073709551606
+    // DEBUG: printi 10
+    // DEBUG: printi -10
   }
   ```
 
@@ -97,15 +86,20 @@ description: Debug
   ```
   Prints value as a 128 bit signed integer
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
   // ...
   @action('act')
   doAction(): void {
-    // NEED example here with proper type casting
+    // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
+    printI128(I128.from(100000));
+    printI128(I128.from(10));
+    printI128(I128.from(-10));
+
+    // Output: 
+    // DEBUG: printi128 100000
+    // DEBUG: printi128 10
+    // DEBUG: printi128 18446744073709551606
   }
   ```
 
@@ -115,15 +109,19 @@ description: Debug
   ```
   Prints value as a 128 bit unsigned integer
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
-  // ...
   @action('act')
   doAction(): void {
-    // NEED example here with proper type casting
+    // NOTE: You need to define type of value explicitly. Otherwise you'll get an error during compilation
+    printU128(I128.from(100000));
+    printU128(I128.from(10));
+    printU128(I128.from(-10));
+
+    // Output: 
+    // DEBUG: printi128 100000
+    // DEBUG: printi128 10
+    // DEBUG: printi128 18446744073709551606
   }
   ```
 
@@ -133,8 +131,7 @@ description: Debug
   ```
   Prints value as single-precision floating point number
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+  Note that floats are imprecise due to precision loss.
 
   <sub>**Example:**</sub>
   ```ts
@@ -142,13 +139,12 @@ description: Debug
   @action('act')
   doAction(): void {
     printsf(123.4);
+    printsf(123.45);
+    printsf(123.456);
+
     // Output 
     // DEBUG: printsf 123.4000015258789
-    printsf(123.45);
-    // Output
     // DEBUG: printsf 123.44999694824219
-    printsf(123.456);
-    // Output
     // DEBUG: printsf 123.45600128173828
   }
   ```
@@ -159,19 +155,18 @@ description: Debug
   ```
   Prints value as double-precision floating point number
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+  Note that floats are imprecise due to precision loss.
 
   <sub>**Example:**</sub>
   ```ts
   // ...
   @action('act')
   doAction(): void {
-    printsdf(123.456789);
+    printdf(123.456789);
+    printdf(123.45678912345679);
+
     // Output
     // DEBUG: printsdf 123.456789
-    printsdf(123.45678912345679);
-    // Output
     // DEBUG: printsdf 123.45678912345679
   }
   ```
@@ -182,15 +177,17 @@ description: Debug
   ```
   Prints value as quadruple-precision floating point number
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
   // ...
   @action('act')
   doAction(): void {
-    // NEED example here with proper type casting
+    printqf(new Float128(1000, 70));
+    printqf(new Float128(4000, 30));
+
+    // Output
+    // DEBUG: printsqf 12096
+    // DEBUG: printsqf 12272
   }
   ```
 
@@ -200,15 +197,13 @@ description: Debug
   ```
   Prints a 64 bit names as base32 encoded string
 
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
   <sub>**Example:**</sub>
   ```ts
   // ...
   @action('act')
   doAction(): void {
     printn(Name.fromString('contract'))
+
     // Output
     // DEBUG: printn contract
   }
@@ -218,10 +213,7 @@ description: Debug
 * ```ts
   function printArray(data: u8[]): void
   ```
-  ?? Not clear how the function should be used. No examples provided.
-
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
+  Prints byte array as string.
 
   <sub>**Example:**</sub>
   ```ts
@@ -231,10 +223,9 @@ description: Debug
     printArray([
         0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64
     ])
+
     // Output:
     // DEBUG: prints Hello world
-
-    // ! Need to provide examples here
   }
   ```
 
@@ -242,12 +233,7 @@ description: Debug
 * ```ts
   function printHex(data: u8[]): void
   ```
-  Prints hexidecimal data
-
-  The function should be used inside the action method of the contract. 
-  The result if the print will be visible in console when you run test with LOG_LEVEL=debug.
-
-  NOT FULLY CLEAN WHAT THIS FUNCTION IS FOR. AND WHAT ARE EXAMPLES.
+  Prints bytes array as hex
 
   <sub>**Example:**</sub>
   ```ts
@@ -257,8 +243,8 @@ description: Debug
     printHex([
         0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64
     ])
+
     // Output
     // DEBUG: printhex 48656c6c6f20776f726c64
-    // ! Need to provide examples here
   }
   ```


### PR DESCRIPTION
Added docs for most of `print` functions. But for some of them I need examples and, probably, some explanations of use cases.
The functions are:
`printI128` — need an example
`printU128` — need an example
`printsf` — need an explanation. I'm not very good in types, I guess, because I don't understand the output. 
Why `printsf(123.4)` gives **123.4000015258789**, but **5.0/10.0** gives **0.5**?
`printqf` — need an example
`printArray` — need an explanation and an example. I've added example with ASCII code, but not sure it is right.
`printHex` — need an example here. Example from https://developers.eos.io/manuals/eosio.cdt/latest/group__console__c/#function-printhex seems to be useless.